### PR TITLE
Refactor content items

### DIFF
--- a/app/Data/BaseContentItem.php
+++ b/app/Data/BaseContentItem.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Data;
+
+use Illuminate\Support\Str;
+
+abstract class BaseContentItem
+{
+    public function __construct(
+        public string $title,
+        public ?string $titleEn = null,
+        public ?string $bodyHtml = null,
+        public ?string $bodyHtmlEn = null,
+        public string $lang = 'de',
+    ) {
+    }
+
+    public function slug(): string
+    {
+        return Str::slug($this->localizedTitle($this->lang));
+    }
+
+    public function localizedTitle(string $locale): string
+    {
+        return $locale === 'en' && $this->titleEn
+            ? $this->titleEn
+            : $this->title;
+    }
+
+    public function localizedBody(string $locale): ?string
+    {
+        return $locale === 'en' && $this->bodyHtmlEn
+            ? $this->bodyHtmlEn
+            : $this->bodyHtml;
+    }
+}

--- a/app/Data/InfoItem.php
+++ b/app/Data/InfoItem.php
@@ -2,22 +2,22 @@
 
 namespace App\Data;
 
-use Illuminate\Support\Str;
 use App\Services\DrupalApiService;
 use App\Services\DrupalApi;
 
-class InfoItem
+class InfoItem extends BaseContentItem
 {
     public function __construct(
         public int $id,
-        public string $title,
-        public ?string $titleEn,
-        public ?string $bodyHtml,
-        public ?string $bodyHtmlEn,
+        string $title,
+        ?string $titleEn,
+        ?string $bodyHtml,
+        ?string $bodyHtmlEn,
         public ?string $imageUrl,
         public array $raw,
-        public string $lang = 'de',
+        string $lang = 'de',
     ) {
+        parent::__construct($title, $titleEn, $bodyHtml, $bodyHtmlEn, $lang);
     }
 
     public static function fromDrupal(array $item, string $locale = 'de'): self
@@ -34,28 +34,9 @@ class InfoItem
         );
     }
 
-    public function slug(): string
-    {
-        return Str::slug($this->localizedTitle($this->lang));
-    }
-
     public function url(string $locale): string
     {
         return '/' . $locale . '/ueber-uns/' . $this->slug();
-    }
-
-    public function localizedTitle(string $locale): string
-    {
-        return $locale === 'en' && $this->titleEn
-            ? $this->titleEn
-            : $this->title;
-    }
-
-    public function localizedBody(string $locale): ?string
-    {
-        return $locale === 'en' && $this->bodyHtmlEn
-            ? $this->bodyHtmlEn
-            : $this->bodyHtml;
     }
 
     public function subinfosFromFieldLinks(): array

--- a/app/Data/NewsItem.php
+++ b/app/Data/NewsItem.php
@@ -2,22 +2,23 @@
 
 namespace App\Data;
 
-use Illuminate\Support\Str;
 use App\Services\DrupalApi;
 
-class NewsItem
+class NewsItem extends BaseContentItem
 {
     public function __construct(
         public string $id,
-        public string $title,
-        public ?string $titleEn,
-        public ?string $bodyHtml,
-        public ?string $bodyHtmlEn,
+        string $title,
+        ?string $titleEn,
+        ?string $bodyHtml,
+        ?string $bodyHtmlEn,
         public ?string $date,
-        public string $lang,
+        string $lang,
         public bool $showDate = false,
         public bool $showTime = false,
-    ) {}
+    ) {
+        parent::__construct($title, $titleEn, $bodyHtml, $bodyHtmlEn, $lang);
+    }
     
     public static function fromDrupal(array $item): self
     {
@@ -37,18 +38,4 @@ class NewsItem
         );
     }      
 
-    public function slug(): string
-    {
-        return Str::slug($this->title);
-    }
-
-    public function localizedTitle(string $locale): string
-    {
-        return $locale === 'en' && $this->titleEn ? $this->titleEn : $this->title;
-    }
-
-    public function localizedBody(string $locale): ?string
-    {
-        return $locale === 'en' && $this->bodyHtmlEn ? $this->bodyHtmlEn : $this->bodyHtml;
-    }
 }

--- a/app/Data/ProjectItem.php
+++ b/app/Data/ProjectItem.php
@@ -2,7 +2,6 @@
 
 namespace App\Data;
 
-use Illuminate\Support\Str;
 use App\Services\DrupalApiService;
 use App\Services\TagHelper;
 use App\Services\DrupalApi;
@@ -10,26 +9,27 @@ use App\Services\DrupalApi;
 use App\Data\RowItem;
 use App\Data\SubinfoItem;
 
-class ProjectItem
+class ProjectItem extends BaseContentItem
 {
     public function __construct(
         public string $id,
-        public string $title,
-        public ?string $titleEn,
-        public ?string $bodyHtml,
-        public ?string $bodyHtmlEn,
+        string $title,
+        ?string $titleEn,
+        ?string $bodyHtml,
+        ?string $bodyHtmlEn,
         public ?string $year,
         public ?string $imageUrl,
         public array $tags = [],
         public bool $overlay = true,
         public bool $darkText = false,
         public string $style = '',
-        public string $lang = 'de',
+        string $lang = 'de',
         public array $raw = [],
         public array $images = [],
         public string $place = '',
         public array $socialMediaItems = [],
     ) {
+        parent::__construct($title, $titleEn, $bodyHtml, $bodyHtmlEn, $lang);
     }
 
     public static function fromDrupal(array $item, string $locale = 'de'): self
@@ -61,24 +61,9 @@ class ProjectItem
         );
     }
 
-    public function slug(): string
-    {
-        return Str::slug($this->title);
-    }
-
     public function url(string $locale): string
     {
         return '/' . $locale . '/projekte/' . $this->slug();
-    }
-
-    public function localizedTitle(string $locale): string
-    {
-        return $locale === 'en' && $this->titleEn ? $this->titleEn : $this->title;
-    }
-
-    public function localizedBody(string $locale): ?string
-    {
-        return $locale === 'en' && $this->bodyHtmlEn ? $this->bodyHtmlEn : $this->bodyHtml;
     }
 
     public function yearFormatted(): ?string

--- a/app/Data/RowItem.php
+++ b/app/Data/RowItem.php
@@ -3,30 +3,30 @@
 
 namespace App\Data;
 
-use Illuminate\Support\Str;
 use App\Services\DrupalApiService;
 use App\Services\TagHelper;
 use App\Services\DrupalApi;
 
-class RowItem
+class RowItem extends BaseContentItem
 {
     public function __construct(
         public string $id,
-        public string $title,
-        public ?string $titleEn = null,
-        public ?string $bodyHtml = null,
-        public ?string $bodyHtmlEn = null,
+        string $title,
+        ?string $titleEn = null,
+        ?string $bodyHtml = null,
+        ?string $bodyHtmlEn = null,
         public ?string $year = null,
         public ?string $imageUrl = null,
         public array $tags = [],
         public bool $overlay = true,
         public bool $darkText = false,
         public string $style = '',
-        public string $lang = 'de',
+        string $lang = 'de',
         public array $raw = [],
         public array $socialMediaItems = [],
 
     ) {
+        parent::__construct($title, $titleEn, $bodyHtml, $bodyHtmlEn, $lang);
     }
 
     public static function fromDrupal(array $item): self
@@ -57,29 +57,11 @@ class RowItem
         );
     }
 
-    public function slug(): string
-    {
-        return Str::slug($this->title);
-    }
-
     public function url(string $locale): string
     {
         return '/' . $locale . '/reihen/' . $this->slug();
     }
 
-    public function localizedTitle(string $locale): string
-    {
-        return $locale === 'en' && $this->titleEn
-            ? $this->titleEn
-            : $this->title;
-    }
-
-    public function localizedBody(string $locale): ?string
-    {
-        return $locale === 'en' && $this->bodyHtmlEn
-            ? $this->bodyHtmlEn
-            : $this->bodyHtml;
-    }
 
     public function tagLabels(string $locale): array
     {


### PR DESCRIPTION
## Summary
- add `BaseContentItem` for shared title/body fields
- extend NewsItem, RowItem, ProjectItem and InfoItem from the new base

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586793486883228385706e838a9d45