### PR TITLE
Fix missing service argument in tag labels

### DIFF
--- a/resources/views/projects/partials/card.blade.php
+++ b/resources/views/projects/partials/card.blade.php
@@ -7,7 +7,7 @@
                 </div>
             @endif
 
-            @foreach($project->tagLabels($locale) as $tagLabel)
+            @foreach($project->tagLabels($locale, app(App\Services\DrupalApiService::class)) as $tagLabel)
                 <div class="tag {{ $project->darkText ? 'borderblack' : 'borderwhite' }}">
                     {{ $tagLabel }}
                 </div>

--- a/resources/views/projects/partials/reihe-card.blade.php
+++ b/resources/views/projects/partials/reihe-card.blade.php
@@ -1,7 +1,7 @@
 <div class="{{ $reihe->style }} card">
     <a class="{{ $reihe->darkText ? 'blacktextcard' : 'whitetextcard' }}" href="/{{ $locale }}/reihen/{{ $reihe->slug() }}">
         <div class="tagcontainer">
-            @foreach ($reihe->tagLabels($locale) as $tag)
+            @foreach ($reihe->tagLabels($locale, app(App\Services\DrupalApiService::class)) as $tag)
                 <div class="tag {{ $reihe->darkText ? 'borderblack' : 'borderwhite' }}">
                     {{ $tag }}
                 </div>


### PR DESCRIPTION
## Summary
- update project and row card templates to pass `DrupalApiService`

## Testing
- `composer test` *(fails: cURL error 56 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859a7bcbc408322a99e93ce2e38a827