### PR TITLE
Fix missing service argument in metainfo and show views

### DIFF
--- a/resources/views/projects/partials/card.blade.php
+++ b/resources/views/projects/partials/card.blade.php
@@ -7,7 +7,7 @@
                 </div>
             @endif
 
-            @foreach($project->tagLabels($locale) as $tagLabel)
+            @foreach($project->tagLabels($locale, app(App\Services\DrupalApiService::class)) as $tagLabel)
                 <div class="tag {{ $project->darkText ? 'borderblack' : 'borderwhite' }}">
                     {{ $tagLabel }}
                 </div>

--- a/resources/views/projects/partials/metainfo.blade.php
+++ b/resources/views/projects/partials/metainfo.blade.php
@@ -14,7 +14,7 @@
     </div>
     @endif
 
-    {!! $item->socialMedia() !!}
+    {!! $item->socialMedia(app(App\Services\SocialMediaRenderer::class)) !!}
 
     {{-- 2) Datumsliste mit Show-More/Show-Less-Logik --}}
     @php
@@ -74,7 +74,7 @@
 
     {{-- Ko-Produzenten --}}
     @php
-    $koproduzenten = $item->coProducers();
+    $koproduzenten = $item->coProducers(app(App\Services\DrupalApiService::class));
     @endphp
     @if(count($koproduzenten))
     <div class="foerderung">
@@ -95,7 +95,7 @@
 
     {{-- Förderer --}}
     @php
-    $foerderer = $item->funders();
+    $foerderer = $item->funders(app(App\Services\DrupalApiService::class));
     @endphp
     @if(count($foerderer))
     <div class="foerderung">
@@ -117,7 +117,7 @@
 
   @else
     {{-- 3) Für Reihen (Social + Projekte in der Serie) --}}
-    {!! $item->socialMedia() !!}
+    {!! $item->socialMedia(app(App\Services\SocialMediaRenderer::class)) !!}
   </div>
 
   <div class="newshead small-text">

--- a/resources/views/projects/partials/reihe-card.blade.php
+++ b/resources/views/projects/partials/reihe-card.blade.php
@@ -1,7 +1,7 @@
 <div class="{{ $reihe->style }} card">
     <a class="{{ $reihe->darkText ? 'blacktextcard' : 'whitetextcard' }}" href="/{{ $locale }}/reihen/{{ $reihe->slug() }}">
         <div class="tagcontainer">
-            @foreach ($reihe->tagLabels($locale) as $tag)
+            @foreach ($reihe->tagLabels($locale, app(App\Services\DrupalApiService::class)) as $tag)
                 <div class="tag {{ $reihe->darkText ? 'borderblack' : 'borderwhite' }}">
                     {{ $tag }}
                 </div>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -12,7 +12,7 @@
                     {{ __('content.projects') }}
                 </a>
 
-                @if ($reihe = $project->reihe())
+                @if ($reihe = $project->reihe(app(App\Services\DrupalApiService::class)))
                     <img
                         id="projekttrenner"
                         alt="{{ __('content.project_separator') }}"


### PR DESCRIPTION
## Summary
- inject DrupalApiService when resolving project's parent row
- inject DrupalApiService and SocialMediaRenderer helpers in metainfo partial

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859a7bcbc408322a99e93ce2e38a827